### PR TITLE
improve memory usage when parsing large tokens

### DIFF
--- a/jsonparse.js
+++ b/jsonparse.js
@@ -40,6 +40,14 @@ var KEY     = C.KEY     = 0x72;
 // Parser Modes
 var OBJECT  = C.OBJECT  = 0x81;
 var ARRAY   = C.ARRAY   = 0x82;
+// Character constants
+var BACK_SLASH =      "\\".charCodeAt(0);
+var FORWARD_SLASH =   "\/".charCodeAt(0);
+var BACKSPACE =       "\b".charCodeAt(0);
+var FORM_FEED =       "\f".charCodeAt(0);
+var NEWLINE =         "\n".charCodeAt(0);
+var CARRIAGE_RETURN = "\r".charCodeAt(0);
+var TAB =             "\t".charCodeAt(0);
 
 var STRING_BUFFER_SIZE = 64 * 1024;
 
@@ -184,13 +192,13 @@ proto.write = function (buffer) {
     }else if (this.tState === STRING2){ // After backslash
       n = buffer[i];
       if(n === 0x22){ this.appendStringChar(n); this.tState = STRING1;
-      }else if(n === 0x5c){ this.appendStringChar("\\".charCodeAt(0)); this.tState = STRING1;
-      }else if(n === 0x2f){ this.appendStringChar("\/".charCodeAt(0)); this.tState = STRING1;
-      }else if(n === 0x62){ this.appendStringChar("\b".charCodeAt(0)); this.tState = STRING1;
-      }else if(n === 0x66){ this.appendStringChar("\f".charCodeAt(0)); this.tState = STRING1;
-      }else if(n === 0x6e){ this.appendStringChar("\n".charCodeAt(0)); this.tState = STRING1;
-      }else if(n === 0x72){ this.appendStringChar("\r".charCodeAt(0)); this.tState = STRING1;
-      }else if(n === 0x74){ this.appendStringChar("\t".charCodeAt(0)); this.tState = STRING1;
+      }else if(n === 0x5c){ this.appendStringChar(BACK_SLASH); this.tState = STRING1;
+      }else if(n === 0x2f){ this.appendStringChar(FORWARD_SLASH); this.tState = STRING1;
+      }else if(n === 0x62){ this.appendStringChar(BACKSPACE); this.tState = STRING1;
+      }else if(n === 0x66){ this.appendStringChar(FORM_FEED); this.tState = STRING1;
+      }else if(n === 0x6e){ this.appendStringChar(NEWLINE); this.tState = STRING1;
+      }else if(n === 0x72){ this.appendStringChar(CARRIAGE_RETURN); this.tState = STRING1;
+      }else if(n === 0x74){ this.appendStringChar(TAB); this.tState = STRING1;
       }else if(n === 0x75){ this.unicode = ""; this.tState = STRING3;
       }else{
         return this.charError(buffer, i);

--- a/jsonparse.js
+++ b/jsonparse.js
@@ -48,7 +48,7 @@ function Parser() {
   this.value = undefined;
 
   this.string = undefined; // string data
-  this.stringBuffer = Buffer.alloc(STRING_BUFFER_SIZE);
+  this.stringBuffer = Buffer.alloc ? Buffer.alloc(STRING_BUFFER_SIZE) : new Buffer(STRING_BUFFER_SIZE);
   this.stringBufferOffset = 0;
   this.unicode = undefined; // unicode escapes
 

--- a/test/big-token.js
+++ b/test/big-token.js
@@ -3,43 +3,22 @@ var JsonParse = require('../jsonparse');
 var test = require('tape');
 
 test('can handle large tokens without running out of memory', function (t) {
-  var size = 1024 * 1024 * 200; // 200mb
-  t.plan(1);
-  largeJsonStream(size).pipe(parseStream(function (type, value) {
-    t.equal(value.length, size, 'token should be size of input json');
-    t.end();
-  }));
-});
-
-function largeJsonStream (size, options) {
-  var jsonStrream = new stream.Readable(options);
-  var sent = 0;
-
-  jsonStrream.push('"');
-
-  jsonStrream._read = function (readSize) {
-    var bytesToSend = Math.min(readSize, size - sent);
-    jsonStrream.push(Buffer.alloc(bytesToSend, 'a'));
-    sent += bytesToSend;
-    if (sent >= size) {
-      jsonStrream.push('"');
-      jsonStrream.push(null);
-    }
-  };
-
-  return jsonStrream;
-}
-
-function parseStream (onToken, options) {
-  var parseStream = new stream.Writable(options);
   var parser = new JsonParse();
+  var chunkSize = 1024
+  var chunks = 1024 * 200; // 200mb
+  var quote = Buffer.from ? Buffer.from('"') : new Buffer('"');
+  t.plan(1);
 
-  parser.onToken = onToken;
-
-  parseStream._write = function (chunk, encoding, cb) {
-    parser.write(chunk);
-    cb();
+  parser.onToken = function (type, value) {
+    t.equal(value.length, chunkSize * chunks, 'token should be size of input json');
+    t.end();
   };
 
-  return parseStream;
-}
+  parser.write(quote);
+  for (var i = 0; i < chunks; ++i) {
+    var buf = Buffer.alloc ? Buffer.alloc(chunkSize) : new Buffer(chunkSize);
+    buf.fill('a');
+    parser.write(buf);
+  }
+  parser.write(quote);
+});

--- a/test/big-token.js
+++ b/test/big-token.js
@@ -4,7 +4,7 @@ var test = require('tape');
 
 test('can handle large tokens without running out of memory', function (t) {
   var parser = new JsonParse();
-  var chunkSize = 1024
+  var chunkSize = 1024;
   var chunks = 1024 * 200; // 200mb
   var quote = Buffer.from ? Buffer.from('"') : new Buffer('"');
   t.plan(1);

--- a/test/big-token.js
+++ b/test/big-token.js
@@ -1,0 +1,45 @@
+var stream = require('stream');
+var JsonParse = require('../jsonparse');
+var test = require('tape');
+
+test('can handle large tokens without running out of memory', function (t) {
+  var size = 1024 * 1024 * 200; // 200mb
+  t.plan(1);
+  largeJsonStream(size).pipe(parseStream(function (type, value) {
+    t.equal(value.length, size, 'token should be size of input json');
+    t.end();
+  }));
+});
+
+function largeJsonStream (size, options) {
+  var jsonStrream = new stream.Readable(options);
+  var sent = 0;
+
+  jsonStrream.push('"');
+
+  jsonStrream._read = function (readSize) {
+    var bytesToSend = Math.min(readSize, size - sent);
+    jsonStrream.push(Buffer.alloc(bytesToSend, 'a'));
+    sent += bytesToSend;
+    if (sent >= size) {
+      jsonStrream.push('"');
+      jsonStrream.push(null);
+    }
+  };
+
+  return jsonStrream;
+}
+
+function parseStream (onToken, options) {
+  var parseStream = new stream.Writable(options);
+  var parser = new JsonParse();
+
+  parser.onToken = onToken;
+
+  parseStream._write = function (chunk, encoding, cb) {
+    parser.write(chunk);
+    cb();
+  };
+
+  return parseStream;
+}


### PR DESCRIPTION
I have been working on a project that handles uploads of large json files, and I have found that there is something very inefficient happening when parsing large string tokens.

The root of the problem seems to be in how v8 handles string concatenation of small strings, I am not yet sure if this is an issue across all node versions, and have only been testing on node 6 so far.

The main symptom of this problem is that parsing a single string token of 50mb (I think the actual cut off is somewhere between 30 and 50) will run a node process out of memory (with the default 1.7gb heap).  I have narrowed the issue down to a single line: https://github.com/creationix/jsonparse/blob/master/jsonparse.js#L137.  I did some heap profiling to try to figure out exactly what was going wrong, but so far don't have a definitive answer to what exactly is using all the memory, but I did find that there were a large number of 64k chunks of memory being allocated. My suspicion is that a 64k chunk is being allocated for each character in the token, and the string representing the token (this.string) is simply a container with pointers to the memory locations of its constituent characters. (I know v8 does this to improve performance and memory use of applications that do a lot of string concatenation).

I have a solution here that seems to solve the memory use issue while still maintaining good performance (I had several other attempts that were far slower 😿 ), but am not 100% sure its the right solution since I am not too familiar with the internals of how strings work in v8.

Let me know what you think, and if there is anything else I can do to help get this addressed.

PS:
I am aware 50mb is a ridiculously large size for a token, but I think you start to see symptoms of this issue with much smaller values, they are just a bit harder to notice, and values of a few mb are not that uncommon