### PR TITLE
use Buffer.from if available

### DIFF
--- a/jsonparse.js
+++ b/jsonparse.js
@@ -54,6 +54,9 @@ var STRING_BUFFER_SIZE = 64 * 1024;
 function alloc(size) {
   return Buffer.alloc ? Buffer.alloc(size) : new Buffer(size);
 }
+function bufferFrom(arg) {
+  return Buffer.from ? Buffer.from(arg) : new Buffer(arg);
+}
 
 function Parser() {
   this.tState = START;
@@ -129,7 +132,7 @@ proto.appendStringBuf = function (buf, start, end) {
   this.stringBufferOffset += size;
 };
 proto.write = function (buffer) {
-  if (typeof buffer === "string") buffer = new Buffer(buffer);
+  if (typeof buffer === "string") buffer = bufferFrom(buffer);
   var n;
   for (var i = 0, l = buffer.length; i < l; i++) {
     if (this.tState === START){
@@ -225,16 +228,16 @@ proto.write = function (buffer) {
           var intVal = parseInt(this.unicode, 16);
           this.unicode = undefined;
           if (this.highSurrogate !== undefined && intVal >= 0xDC00 && intVal < (0xDFFF + 1)) { //<56320,57343> - lowSurrogate
-            this.appendStringBuf(new Buffer(String.fromCharCode(this.highSurrogate, intVal)));
+            this.appendStringBuf(bufferFrom(String.fromCharCode(this.highSurrogate, intVal)));
             this.highSurrogate = undefined;
           } else if (this.highSurrogate === undefined && intVal >= 0xD800 && intVal < (0xDBFF + 1)) { //<55296,56319> - highSurrogate
             this.highSurrogate = intVal;
           } else {
             if (this.highSurrogate !== undefined) {
-              this.appendStringBuf(new Buffer(String.fromCharCode(this.highSurrogate)));
+              this.appendStringBuf(bufferFrom(String.fromCharCode(this.highSurrogate)));
               this.highSurrogate = undefined;
             }
-            this.appendStringBuf(new Buffer(String.fromCharCode(intVal)));
+            this.appendStringBuf(bufferFrom(String.fromCharCode(intVal)));
           }
           this.tState = STRING1;
         }

--- a/test/boundary.js
+++ b/test/boundary.js
@@ -1,6 +1,8 @@
 var test = require('tape');
 var Parser = require('../');
-
+function bufferFrom(arg) {
+  return Buffer.from ? Buffer.from(arg) : new Buffer(arg);
+}
 test('2 byte utf8 \'De\' character: д', function (t) {
   t.plan(1);
 
@@ -9,7 +11,7 @@ test('2 byte utf8 \'De\' character: д', function (t) {
     t.equal(value, 'д');
   };
 
-  var de_buffer = new Buffer([0xd0, 0xb4]);
+  var de_buffer = bufferFrom([0xd0, 0xb4]);
 
   p.write('"');
   p.write(de_buffer);
@@ -25,7 +27,7 @@ test('3 byte utf8 \'Han\' character: 我', function (t) {
     t.equal(value, '我');
   };
 
-  var han_buffer = new Buffer([0xe6, 0x88, 0x91]);
+  var han_buffer = bufferFrom([0xe6, 0x88, 0x91]);
   p.write('"');
   p.write(han_buffer);
   p.write('"');
@@ -39,7 +41,7 @@ test('4 byte utf8 character (unicode scalar U+2070E): 𠜎', function (t) {
     t.equal(value, '𠜎');
   };
 
-  var Ux2070E_buffer = new Buffer([0xf0, 0xa0, 0x9c, 0x8e]);
+  var Ux2070E_buffer = bufferFrom([0xf0, 0xa0, 0x9c, 0x8e]);
   p.write('"');
   p.write(Ux2070E_buffer);
   p.write('"');
@@ -53,8 +55,8 @@ test('3 byte utf8 \'Han\' character chunked inbetween 2nd and 3rd byte: 我', fu
     t.equal(value, '我');
   };
 
-  var han_buffer_first = new Buffer([0xe6, 0x88]);
-  var han_buffer_second = new Buffer([0x91]);
+  var han_buffer_first = bufferFrom([0xe6, 0x88]);
+  var han_buffer_second = bufferFrom([0x91]);
   p.write('"');
   p.write(han_buffer_first);
   p.write(han_buffer_second);
@@ -69,8 +71,8 @@ test('4 byte utf8 character (unicode scalar U+2070E) chunked inbetween 2nd and 3
     t.equal(value, '𠜎');
   };
 
-  var Ux2070E_buffer_first = new Buffer([0xf0, 0xa0]);
-  var Ux2070E_buffer_second = new Buffer([0x9c, 0x8e]);
+  var Ux2070E_buffer_first = bufferFrom([0xf0, 0xa0]);
+  var Ux2070E_buffer_second = bufferFrom([0x9c, 0x8e]);
   p.write('"');
   p.write(Ux2070E_buffer_first);
   p.write(Ux2070E_buffer_second);
@@ -85,7 +87,7 @@ var p = new Parser();
     t.equal(value, 'Aж文𠜱B');
   };
 
-  var eclectic_buffer = new Buffer([0x41, // A
+  var eclectic_buffer = bufferFrom([0x41, // A
                                     0xd0, 0xb6, // ж
                                     0xe6, 0x96, 0x87, // 文
                                     0xf0, 0xa0, 0x9c, 0xb1, // 𠜱


### PR DESCRIPTION
new Buffer is deprecated, so Buffer.from should be used if it's available